### PR TITLE
Add video and audio error handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Available options are:
 
 *onError* - function. Will be fired if jMuxer encounters any buffer related errors.
 
-*onVideoFeedError* - function. Will be fired if jMuxer encounters any video feeding related errors.
+*onMissingVideoFrames* - function. Will be fired if jMuxer encounters any missing video frames.
 
-*onAudioFeedError* - function. Will be fired if jMuxer encounters any audio feeding related errors.
+*onMissingAudioFrames* - function. Will be fired if jMuxer encounters any missing audio frames.
 
 *debug* - true/false. Will print debug log in browser console. Default is false.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ Available options are:
 
 *onReady* - function. Will be called once MSE is ready.
 
-*onError* - function. Will be fired if jMuxer encounters any buffer error.
+*onError* - function. Will be fired if jMuxer encounters any buffer related errors.
+
+*onVideoFeedError* - function. Will be fired if jMuxer encounters any video feeding related errors.
+
+*onAudioFeedError* - function. Will be fired if jMuxer encounters any audio feeding related errors.
 
 *debug* - true/false. Will print debug log in browser console. Default is false.
 

--- a/example/index.html
+++ b/example/index.html
@@ -39,6 +39,12 @@
         flushingTime: 1000, // we need 1000 for the demo as server provides a chunk data of 1000ms at a time
         onError: function(data) {
             console.log('Buffer error encountered', data);
+        },
+        onVideoFeedError: function (data) {
+            console.log('Video feeding error encountered', data);
+        },
+        onAudioFeedError: function (data) {
+            console.log('Audio feeding error encountered', data);
         }
      });
 

--- a/example/index.html
+++ b/example/index.html
@@ -40,11 +40,11 @@
         onError: function(data) {
             console.log('Buffer error encountered', data);
         },
-        onVideoFeedError: function (data) {
-            console.log('Video feeding error encountered', data);
+        onMissingVideoFrames: function (data) {
+            console.log('Video frames missing', data);
         },
-        onAudioFeedError: function (data) {
-            console.log('Audio feeding error encountered', data);
+        onMissingAudioFrames: function (data) {
+            console.log('Audio frames missing', data);
         }
      });
 

--- a/src/jmuxer.js
+++ b/src/jmuxer.js
@@ -27,8 +27,8 @@ export default class JMuxer extends Event {
             debug: false,
             onReady: function() {}, // function called when MSE is ready to accept frames
             onError: function() {}, // function called when jmuxer encounters any buffer related errors
-            onVideoFeedError: function () {}, // function called when jmuxer encounters any video feeding related errors
-            onAudioFeedError: function () {}, // function called when jmuxer encounters any audio feeding related errors
+            onMissingVideoFrames: function () {}, // function called when jmuxer encounters any missing video frames
+            onMissingAudioFrames: function () {}, // function called when jmuxer encounters any missing audio frames
         };
         this.options = Object.assign({}, defaults, options);
         this.env = typeof process === 'object' && typeof window === 'undefined' ? 'node' : 'browser';
@@ -140,8 +140,8 @@ export default class JMuxer extends Event {
                 remux = true;
             } else {
                 debug.error('Failed to extract any NAL units from video data:', left);
-                if (typeof this.options.onVideoFeedError === 'function') {
-                    this.options.onVideoFeedError.call(null, data);
+                if (typeof this.options.onMissingVideoFrames === 'function') {
+                    this.options.onMissingVideoFrames.call(null, data);
                 }
                 return;
             }
@@ -153,8 +153,8 @@ export default class JMuxer extends Event {
                 remux = true;
             } else {
                 debug.error('Failed to extract audio data from:', data.audio);
-                if (typeof this.options.onAudioFeedError === 'function') {
-                    this.options.onAudioFeedError.call(null, data);
+                if (typeof this.options.onMissingAudioFrames === 'function') {
+                    this.options.onMissingAudioFrames.call(null, data);
                 }
                 return;
             }

--- a/src/jmuxer.js
+++ b/src/jmuxer.js
@@ -26,7 +26,9 @@ export default class JMuxer extends Event {
             readFpsFromTrack: false, // set true to fetch fps value from NALu
             debug: false,
             onReady: function() {}, // function called when MSE is ready to accept frames
-            onError: function() {}, // function called when jmuxer encounters any buffer related error
+            onError: function() {}, // function called when jmuxer encounters any buffer related errors
+            onVideoFeedError: function () {}, // function called when jmuxer encounters any video feeding related errors
+            onAudioFeedError: function () {}, // function called when jmuxer encounters any audio feeding related errors
         };
         this.options = Object.assign({}, defaults, options);
         this.env = typeof process === 'object' && typeof window === 'undefined' ? 'node' : 'browser';
@@ -138,6 +140,9 @@ export default class JMuxer extends Event {
                 remux = true;
             } else {
                 debug.error('Failed to extract any NAL units from video data:', left);
+                if (typeof this.options.onVideoFeedError === 'function') {
+                    this.options.onVideoFeedError.call(null, data);
+                }
                 return;
             }
         }
@@ -148,6 +153,9 @@ export default class JMuxer extends Event {
                 remux = true;
             } else {
                 debug.error('Failed to extract audio data from:', data.audio);
+                if (typeof this.options.onAudioFeedError === 'function') {
+                    this.options.onAudioFeedError.call(null, data);
+                }
                 return;
             }
         }


### PR DESCRIPTION
This PR allows a user to catch any video/audio feeding errors and act accordingly (show UI error states, make API request etc).